### PR TITLE
TLS Connectivity option fix

### DIFF
--- a/credentials/NatsApi.credentials.ts
+++ b/credentials/NatsApi.credentials.ts
@@ -44,7 +44,8 @@ export class NatsApi implements ICredentialType {
 			default: undefined,
 			placeholder: 'PEM ca',
 			description: 'TLS Certificate Authority',
-      typeOptions: {
+      		typeOptions: {
+				rows: 4,
 				alwaysOpenEditWindow: true
 			},
 			displayOptions: {
@@ -109,7 +110,8 @@ export class NatsApi implements ICredentialType {
 			placeholder: 'PEM Cert',
 			description: 'TLS Certificate',
 			typeOptions: {
-				alwaysOpenEditWindow: true
+				alwaysOpenEditWindow: true,
+				rows: 4,
 			},
 			displayOptions: {
 				show: {
@@ -123,7 +125,7 @@ export class NatsApi implements ICredentialType {
 			type: 'string',
 			typeOptions: {
 				alwaysOpenEditWindow: true,
-				password: true
+				rows: 4,
 			},
 			default: undefined,
 			placeholder: 'PEM key',

--- a/nodes/common.ts
+++ b/nodes/common.ts
@@ -49,8 +49,7 @@ export function natsConnectionOptions(credentials: ICredentialDataDecryptedObjec
 			authenticators.push(credsAuthenticator(new TextEncoder().encode(creds as string)))
 		  break
 		case 'tls':
-			options.tls = { ca: tlsCa }
-			options.tls.cert = { ...options.tls, cert: tlsCert, key: tlsKey }
+			options.tls = { ca: tlsCa, cert: tlsCert, key: tlsKey }
 		  break
 	}
 


### PR DESCRIPTION
Hey there, I noticed two more issues when trying to establish TLS encrypted communication.

First, the tlsOptions must be set directly, also the certificate and key files must be multiline strings, as otherwise newline characters get removed, causing the connection to fail.